### PR TITLE
修正译名表弗拉斯塔·维里科娃人名错字

### DIFF
--- a/books/99/012-译名对照表.md
+++ b/books/99/012-译名对照表.md
@@ -24,7 +24,7 @@
 | Zheng Ying-zhi      | 郑颖芝             | 结界使                    |
 | Mina Guyure         | 弥娜·古耶尔        | 传送者                    |
 | Shizuki Elanis      | 志筑·爱兰尼斯      |                           |
-| Vlasta Werichová      | 弗拉斯塔·维瑞科娃      |                           |
+| Vlasta Werichová      | 弗拉斯塔·维里科娃      |                           |
 | Christina San Miguel      | 克里斯蒂娜·圣米格尔      |                           |
 | Mila Brankovich      | 米拉·布朗科维奇      |                           |
 | Kuroi Eri           | 黑井英理           | **旧译** “黒井英理”       |


### PR DESCRIPTION
71章的新角色弗拉斯塔·维里科娃，之前译名表里错打成维瑞科娃，现修正