### PR TITLE
译名表添加黑井安倍/佐藤丽香/米沙·维拉尼人名

### DIFF
--- a/books/99/012-译名对照表.md
+++ b/books/99/012-译名对照表.md
@@ -27,10 +27,13 @@
 | Vlasta Werichová     | 弗拉斯塔·维里科娃   |                                 |
 | Christina San Miguel | 克里斯蒂娜·圣米格尔 |                                 |
 | Mila Brankovich      | 米拉·布朗科维奇     |                                 |
+| Misa Virani      | 米沙·维拉尼     |                                 |
 | Anna Tomova          | 安娜·托莫娃         |                                 |
 | Cynthia Rittner      | 辛西娅·里特纳       |                                 |
 | Kuroi Eri            | 黑井英理            | **旧译** “黒井英理”             |
 | Kuroi Kana           | 黑井香菜            |                                 |
+| Kuroi Abe         | 黑井安倍            |                                 |
+| Sato Reika         | 佐藤丽香            |                                 |
 | Azrael               | 阿兹瑞尔            | 读心者                          |
 | Volokhov             | 沃洛科夫            |                                 |
 | Machina              | 机械娘              | 战术电脑                        |
@@ -91,6 +94,9 @@
 | Positive-exchange    | 积极-交流者         |                                 |
 | World-shaping        | 世界-塑造者         |                                 |
 | World-beholding      | 世界-观察者         |                                 |
+| Fossil-hunter      | 化石-狩猎者            |                                 |
+| Perspective-pursuer      | 观点-追寻者           |                                 |
+| Raptor-weaving      | 猛禽-编织者         |                                 |
 | Cooperator           | 合作者              |                                 |
 | Comprehending        | 理解者              |                                 |
 | Humanity-preserving  | 人类-保护者         | 良子的星际名                    |


### PR DESCRIPTION
添加三个人名、三个新章节出现的思裔人名

Kuroi Abe 黑井安倍 
Sato Reika 佐藤丽香 
Misa Virani 米沙·维拉尼
Fossil-hunter 化石-狩猎者
Perspective-pursuer 观点-追寻者
Raptor-weaving 猛禽-编织者